### PR TITLE
Update Backup-GroupPolicy.ps1

### DIFF
--- a/Active-Directory/Backup-GroupPolicy.ps1
+++ b/Active-Directory/Backup-GroupPolicy.ps1
@@ -63,15 +63,26 @@ param (
 
     [Parameter()]
     [string]
-    $Domain = (Get-WmiObject Win32_ComputerSystem).Domain,
+    $Domain = $env:USERDNSDOMAIN,
 
-    [Parameter()]
-    [string]
+    # Specify aliases for the Server parameter and support tab completion for domain controller names.
+    [Parameter(]
+    [Alias("DomainController","DC")]
+    [ArgumentCompleter( {
+        param ( $commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters )
+        $possibleValues = @{ Server = (Get-ADDomainController -Filter *).Hostname }
+        if ($fakeBoundParameters.ContainsKey('Type')) { $possibleValues[$fakeBoundParameters.Type] | Where-Object { $_ -like "$wordToComplete*" } }
+        else { $possibleValues.Values | ForEach-Object {$_} }
+    } )]
     $Server
-    )
+
+    ) #End of Parameter Declarations
 
     begin {
 
+        # Get a domain controller if none was specified with by server parameter
+        If (-Not $Server) { $Server = (Get-ADDomainController).Hostname }
+        
         # Get current GPO information
         $GPOInfo = Get-GPO -All -Domain $domain -Server $Server
 
@@ -80,9 +91,9 @@ param (
         $Date = Get-Date -UFormat "%Y-%m-%d"
         $UpdatedPath = "$path\$date"
 
-        New-item $UpdatedPath -ItemType directory | Out-Null
+        If (-Not $UpdatedPath) { New-item $UpdatedPath -ItemType directory | Out-Null }
 
-        Write-Host "GPO's will be backed up to $UpdatedPath" -backgroundcolor white -foregroundColor red
+        Write-Host "GPOs will be backed up to $UpdatedPath" -backgroundcolor white -foregroundColor red
     } #end of begin block
 
     process {
@@ -111,4 +122,4 @@ param (
 
     end {
     } #End of End block
-} #end of function
+} #end of function 


### PR DESCRIPTION
1. Replaced WMI query for the domain name with a reference to the system environment variable for the current user's domain. Avoids the expense of running a WMI query.
2. Removed the Mandatory attribute from the Server parameter. This was missing a Boolean setting, and compensating code is added below.
3. Since your blog post mentioned thoughts around using "Server" vs "DomainController" or "DC" for the parameter name, I though you might like an alias for this!
4. Added tab autocomplete for the server parameter, which fills in domain controller names automatically! Lines
5. Gets a domain controller name for the Server parameter if no server parameter is specified.
6. Checks to see if $UpdatePath does not exist, creates the new backup folder if it does not exist yet. No errors now if the folder already exists. My goal is to be able to run this multiple times per day, if necessary.
7. Grammar police removed the apostrophe from "GPOs"