### PR TITLE
Update Backup-GroupPolicy.ps1

### DIFF
--- a/Active-Directory/Backup-GroupPolicy.ps1
+++ b/Active-Directory/Backup-GroupPolicy.ps1
@@ -109,7 +109,7 @@ param (
             $BackupInfo = Backup-GPO -Name $($GPO.DisplayName) -Domain $Domain -path $UpdatedPath -Server $Server
             $GpoBackupID = $BackupInfo.ID.Guid
             $GpoGuid = $BackupInfo.GPOID.Guid
-            $GpoName = $BackupInfo.DisplayName
+            $GpoName = $BackupInfo.DisplayName -replace '[\/\\]', '_'
             $CurrentFolderName = $UpdatedPath + "\" + "{"+ $GpoBackupID + "}"
             $NewFolderName = $UpdatedPath + "\" + $GPOName + "___" + "{"+ $GpoBackupID + "}"
             $ConsoleOutput = $GPOName + "___" + "{"+ $GpoBackupID + "}"


### PR DESCRIPTION
Handle slashes that may exist in GPO names, otherwise rename-item can fail.